### PR TITLE
Speed up processing 'fixit.txt' by removing duplicate entries

### DIFF
--- a/updateDependencies.sh
+++ b/updateDependencies.sh
@@ -7,5 +7,6 @@ while read line
 done <all-ports.txt
 
 ./removeVersions >fixit.txt
-sqlite3 ports.db -init fixit.txt '.quit'
-rm fixit.txt
+sort -u fixit.txt > fixit2.txt
+sqlite3 ports.db -init fixit2.txt '.quit'
+rm fixit.txt fixit2.txt


### PR DESCRIPTION
Simply removing the duplicate entries from `fixit.txt` before letting sqlite munch on it accounts for a nice speedup on my laptop:

before:
sqlite3 ports.db -init fixit.txt.orig '.quit'  238.69s user 83.20s system 99% cpu 5:23.45 total

after:
sqlite3 ports.db -init fixit.txt.new '.quit'  65.62s user 22.37s system 99% cpu 1:28.23 total
